### PR TITLE
use six instead of future

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install jieba future
+        python -m pip install jieba six
     - name: run unittest
       run: |
         python -m unittest discover tests

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,27 @@
+name: unittest
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["2.7", "3.10", "3.11"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install jieba future
+    - name: run unittest
+      run: |
+        python -m unittest discover tests

--- a/pinyin/__init__.py
+++ b/pinyin/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from builtins import object
 from io import open
 
 import jieba
@@ -11,7 +10,7 @@ from itertools import product, islice
 
 from pinyin.config import FILE_WORDS, FILE_WORD, FILE_TERM, FILE_USER_DICT, CHINESE_RE
 from pinyin.utils import Singleton
-from future.utils import with_metaclass
+from six import with_metaclass
 
 __all__ = ["Pinyin"]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', 'rt') as f:
 
 setup(
     name='smart_pinyin',
-    version='0.4.5',
+    version='0.4.6',
     description='Smart Chinese-to-Pinyin converter.',
     author='mapix',
     author_email='mapix.me@gmail.com',
@@ -25,6 +25,6 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
     ],
-    install_requires=['jieba', 'future'],
+    install_requires=['jieba', 'six'],
     **extra
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = py27,py35
-
-[testenv]
-deps=
-    pytest
-    mock
-commands=py.test tests


### PR DESCRIPTION
`future` pollutes Python standard library in Python 2.7,
which introduces some bugs.

So I remove `future` and use `six` instead.